### PR TITLE
Fixed deprecation warnings

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -59,7 +59,7 @@ module.exports =
       .toLowerCase()
 
     isEditable =
-      typeof item != 'undefined' and typeof item.displayBuffer != 'undefined'
+      typeof item != 'undefined' and item?.buffer
 
     if currentFileExtension in extensions or not isEditable
       view.css("display", "none")


### PR DESCRIPTION
I'm running Atom 1.13.1 which removes `TextEditor.prototype.displayBuffer`. Here's the error Atom spits out:

> `TextEditor.prototype.displayBuffer` has always been private, but now it is gone. Reading the displayBuffer property now returns a reference to the containing `TextEditor`, which now provides some of the API of the defunct `DisplayBuffer` class.

```
TextEditor.get - /Applications/Atom.app/Contents/Resources/app.asar/src/text-editor.js:101:14
Object.showOrHide - /Users/calazans/.atom/packages/counter/lib/main.coffee:75:62
Object.activate - /Users/calazans/.atom/packages/counter/lib/main.coffee:67:19
Package.activateNow - /Applications/Atom.app/Contents/Resources/app.asar/src/package.js:191:19
<unknown> - /Applications/Atom.app/Contents/Resources/app.asar/src/package.js:164:32
Package.measure - /Applications/Atom.app/Contents/Resources/app.asar/src/package.js:94:15
```
